### PR TITLE
Update Lev_search.c to remove undefined C behavior and follow c-api

### DIFF
--- a/Lev_search.c
+++ b/Lev_search.c
@@ -928,9 +928,9 @@ static PyModuleDef module_def = {
 	NULL
 };
 
-PyMODINIT_FUNC PyInit_Levenshtein_search()
+PyMODINIT_FUNC PyInit_Levenshtein_search(void)
 {
-	PyObject *m = PyModule_Create(&module_def);
+	return PyModule_Create(&module_def);
 }
 #else
 PyMODINIT_FUNC initLevenshtein_search(void)


### PR DESCRIPTION
What?: 
Updating  PyInit_Levenshtein_search to match https://docs.python.org/3/extending/extending.html#the-module-s-method-table-and-initialization-function

Why?: 
I was building this module using clang for cPython 3.8 with AddressSanitizer enabled and was getting a segfault of the process after attempting to import the module. 

When the module init  function has no return statement it causes the Python GC system to read a random memory address.  While I guess in normal use this might not always cause bad things to happen.  But with Address Sanitizer in clang enabled it noticed cPython doing it and SEGV.    

Why is the GC doing this?:  
"If a function in C expects a return and no return statement is executed during function flow the return value of the function is undefined. "

Python expects the returned pointer address to either be a PyObject or NULL.    Since its some kind of random address who knows what is really happening. 

The stack trace before my fix:
```
=================================================================
==1744834==ERROR: AddressSanitizer: SEGV on unknown address 0x7f00007f14fb (pc 0x7f1505a4d7a3 bp 0x7ffe9058e0d0 sp 0x7ffe9058e0b0 T0)
==1744834==The signal is caused by a READ memory access.
SCARINESS: 20 (wild-addr-read)
    #0 0x7f1505a4d7a3 in _PyObject_GC_UNTRACK_impl Include/internal/pycore_object.h:70:5
    #1 0x7f1505a4d7a3 in PyObject_GC_UnTrack Modules/gcmodule.c:1947:9
    #2 0x7f1505a4d7a3 in tupledealloc Objects/tupleobject.c:242:5
    #3 0x7f1505a65340 in _Py_Dealloc Objects/object.c:2215:6
    #4 0x7f1505a65340 in _Py_DECREF Include/object.h:478:9
    #5 0x7f1505a65340 in func_clear Objects/funcobject.c:584:5
    #6 0x7f1505a65340 in func_dealloc Objects/funcobject.c:597:11
    #7 0x7f1505a5df77 in _Py_Dealloc Objects/object.c:2215:6
    #8 0x7f1505a5df77 in _Py_DECREF Include/object.h:478:9
    #9 0x7f1505a5df77 in frame_dealloc Objects/frameobject.c:430:9
    #10 0x7f1505a4ddbb in _Py_Dealloc Objects/object.c:2215:6
    #11 0x7f1505a4ddbb in _Py_DECREF Include/object.h:478:9
    #12 0x7f1505a4ddbb in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4350:9
    #13 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #14 0x7f1505a4f934 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #15 0x7f1505a4f934 in call_function Python/ceval.c:4999:13
    #16 0x7f1505a4f934 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #17 0x7f1505a6758f in PyEval_EvalFrameEx Python/ceval.c:769:12
    #18 0x7f1505a6758f in function_code_fastcall Objects/call.c:283:14
    #19 0x7f1505a6758f in _PyFunction_Vectorcall.localalias Objects/call.c:410:20
    #20 0x7f1505a506da in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #21 0x7f1505a506da in call_function Python/ceval.c:4999:13
    #22 0x7f1505a506da in _PyEval_EvalFrameDefault Python/ceval.c:3497:23
    #23 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #24 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #25 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #26 0x7f1505a4f934 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #27 0x7f1505a4f934 in call_function Python/ceval.c:4999:13
    #28 0x7f1505a4f934 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #29 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #30 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #31 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #32 0x7f1505a4f934 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #33 0x7f1505a4f934 in call_function Python/ceval.c:4999:13
    #34 0x7f1505a4f934 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #35 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #36 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #37 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #38 0x7f1505a506da in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #39 0x7f1505a506da in call_function Python/ceval.c:4999:13
    #40 0x7f1505a506da in _PyEval_EvalFrameDefault Python/ceval.c:3497:23
    #41 0x7f1505a7428b in PyEval_EvalFrameEx Python/ceval.c:769:12
    #42 0x7f1505a7428b in function_code_fastcall Objects/call.c:283:14
    #43 0x7f1505a7428b in _PyFunction_Vectorcall Objects/call.c:410:20
    #44 0x7f1505a7428b in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #45 0x7f1505a7428b in _PyObject_FastCall Include/cpython/abstract.h:147:12
    #46 0x7f1505a7428b in property_descr_get Objects/descrobject.c:1496:12
    #47 0x7f1505a65b41 in _PyObject_GenericGetAttrWithDict.localalias Objects/object.c:1254:19
    #48 0x7f1505a4fdee in _PyEval_EvalFrameDefault Python/ceval.c:2994:29
    #49 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #50 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #51 0x7f1505a77ea1 in _PyFunction_Vectorcall Objects/call.c:435:12
    #52 0x7f1505a77ea1 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #53 0x7f1505a77ea1 in method_vectorcall Objects/classobject.c:60:18
    #54 0x7f1505a50e6b in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #55 0x7f1505a50e6b in call_function Python/ceval.c:4999:13
    #56 0x7f1505a50e6b in _PyEval_EvalFrameDefault Python/ceval.c:3543:19
    #57 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #58 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #59 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #60 0x7f1505a5da0f in _PyObject_FastCallDict.localalias Objects/call.c:104:15
    #61 0x7f1505a73698 in _PyObject_Call_Prepend Objects/call.c:887:14
    #62 0x7f1505a73698 in slot_tp_init Objects/typeobject.c:6787:15
    #63 0x7f1505a5e3e6 in type_call Objects/typeobject.c:994:19
    #64 0x7f1505a5e3e6 in _PyObject_MakeTpCall.localalias Objects/call.c:159:18
    #65 0x7f1505a55cbc in _PyObject_Vectorcall Include/cpython/abstract.h:125:16
    #66 0x7f1505a55cbc in _PyObject_Vectorcall Include/cpython/abstract.h:115:1
    #67 0x7f1505a55cbc in call_function Python/ceval.c:4999:13
    #68 0x7f1505a55cbc in _PyEval_EvalFrameDefault Python/ceval.c:3543:19
    #69 0x7f1505a6758f in PyEval_EvalFrameEx Python/ceval.c:769:12
    #70 0x7f1505a6758f in function_code_fastcall Objects/call.c:283:14
    #71 0x7f1505a6758f in _PyFunction_Vectorcall.localalias Objects/call.c:410:20
    #72 0x7f1505a4fbb8 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #73 0x7f1505a4fbb8 in call_function Python/ceval.c:4999:13
    #74 0x7f1505a4fbb8 in _PyEval_EvalFrameDefault Python/ceval.c:3514:23
    #75 0x7f1505a6758f in PyEval_EvalFrameEx Python/ceval.c:769:12
    #76 0x7f1505a6758f in function_code_fastcall Objects/call.c:283:14
    #77 0x7f1505a6758f in _PyFunction_Vectorcall.localalias Objects/call.c:410:20
    #78 0x7f1505a7bd42 in PyVectorcall_Call Objects/call.c:199:24
    #79 0x7f1505a7bd42 in PyObject_Call.localalias Objects/call.c:227:16
    #80 0x7f1505a52958 in do_call_core Python/ceval.c:5046:12
    #81 0x7f1505a52958 in _PyEval_EvalFrameDefault Python/ceval.c:3587:22
    #82 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #83 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #84 0x7f1505a77ea1 in _PyFunction_Vectorcall Objects/call.c:435:12
    #85 0x7f1505a77ea1 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #86 0x7f1505a77ea1 in method_vectorcall Objects/classobject.c:60:18
    #87 0x7f1505a506da in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #88 0x7f1505a506da in call_function Python/ceval.c:4999:13
    #89 0x7f1505a506da in _PyEval_EvalFrameDefault Python/ceval.c:3497:23
    #90 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #91 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #92 0x7f1505a77ea1 in _PyFunction_Vectorcall Objects/call.c:435:12
    #93 0x7f1505a77ea1 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #94 0x7f1505a77ea1 in method_vectorcall Objects/classobject.c:60:18
    #95 0x7f1505a506da in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #96 0x7f1505a506da in call_function Python/ceval.c:4999:13
    #97 0x7f1505a506da in _PyEval_EvalFrameDefault Python/ceval.c:3497:23
    #98 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #99 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #100 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #101 0x7f1505a4fbb8 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #102 0x7f1505a4fbb8 in call_function Python/ceval.c:4999:13
    #103 0x7f1505a4fbb8 in _PyEval_EvalFrameDefault Python/ceval.c:3514:23
    #104 0x7f1505a6758f in PyEval_EvalFrameEx Python/ceval.c:769:12
    #105 0x7f1505a6758f in function_code_fastcall Objects/call.c:283:14
    #106 0x7f1505a6758f in _PyFunction_Vectorcall.localalias Objects/call.c:410:20
    #107 0x7f1505a4fbb8 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #108 0x7f1505a4fbb8 in call_function Python/ceval.c:4999:13
    #109 0x7f1505a4fbb8 in _PyEval_EvalFrameDefault Python/ceval.c:3514:23
    #110 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #111 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #112 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #113 0x7f1505a77f20 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #114 0x7f1505a77f20 in method_vectorcall Objects/classobject.c:89:18
    #115 0x7f1505a7bd42 in PyVectorcall_Call Objects/call.c:199:24
    #116 0x7f1505a7bd42 in PyObject_Call.localalias Objects/call.c:227:16
    #117 0x7f1505a52958 in do_call_core Python/ceval.c:5046:12
    #118 0x7f1505a52958 in _PyEval_EvalFrameDefault Python/ceval.c:3587:22
    #119 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #120 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #121 0x7f1505a5d9bd in _PyFunction_Vectorcall Objects/call.c:435:12
    #122 0x7f1505a5d9bd in _PyObject_FastCallDict.localalias Objects/call.c:96:15
    #123 0x7f1505a73b91 in _PyObject_Call_Prepend.localalias Objects/call.c:887:14
    #124 0x7f1505b4cb5b in slot_tp_call Objects/typeobject.c:6553:15
    #125 0x7f1505a5e3c7 in _PyObject_MakeTpCall.localalias Objects/call.c:159:18
    #126 0x7f1505a50660 in _PyObject_Vectorcall Include/cpython/abstract.h:125:16
    #127 0x7f1505a50660 in _PyObject_Vectorcall Include/cpython/abstract.h:115:1
    #128 0x7f1505a50660 in call_function Python/ceval.c:4999:13
    #129 0x7f1505a50660 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #130 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #131 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #132 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #133 0x7f1505a77f20 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #134 0x7f1505a77f20 in method_vectorcall Objects/classobject.c:89:18
    #135 0x7f1505a7bd42 in PyVectorcall_Call Objects/call.c:199:24
    #136 0x7f1505a7bd42 in PyObject_Call.localalias Objects/call.c:227:16
    #137 0x7f1505a52958 in do_call_core Python/ceval.c:5046:12
    #138 0x7f1505a52958 in _PyEval_EvalFrameDefault Python/ceval.c:3587:22
    #139 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #140 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #141 0x7f1505a5d9bd in _PyFunction_Vectorcall Objects/call.c:435:12
    #142 0x7f1505a5d9bd in _PyObject_FastCallDict.localalias Objects/call.c:96:15
    #143 0x7f1505a73b91 in _PyObject_Call_Prepend.localalias Objects/call.c:887:14
    #144 0x7f1505b4cb5b in slot_tp_call Objects/typeobject.c:6553:15
    #145 0x7f1505a5e3c7 in _PyObject_MakeTpCall.localalias Objects/call.c:159:18
    #146 0x7f1505a50660 in _PyObject_Vectorcall Include/cpython/abstract.h:125:16
    #147 0x7f1505a50660 in _PyObject_Vectorcall Include/cpython/abstract.h:115:1
    #148 0x7f1505a50660 in call_function Python/ceval.c:4999:13
    #149 0x7f1505a50660 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #150 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #151 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #152 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #153 0x7f1505a77f20 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #154 0x7f1505a77f20 in method_vectorcall Objects/classobject.c:89:18
    #155 0x7f1505a7bd42 in PyVectorcall_Call Objects/call.c:199:24
    #156 0x7f1505a7bd42 in PyObject_Call.localalias Objects/call.c:227:16
    #157 0x7f1505a52958 in do_call_core Python/ceval.c:5046:12
    #158 0x7f1505a52958 in _PyEval_EvalFrameDefault Python/ceval.c:3587:22
    #159 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #160 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #161 0x7f1505a5d9bd in _PyFunction_Vectorcall Objects/call.c:435:12
    #162 0x7f1505a5d9bd in _PyObject_FastCallDict.localalias Objects/call.c:96:15
    #163 0x7f1505a73b91 in _PyObject_Call_Prepend.localalias Objects/call.c:887:14
    #164 0x7f1505b4cb5b in slot_tp_call Objects/typeobject.c:6553:15
    #165 0x7f1505a5e3c7 in _PyObject_MakeTpCall.localalias Objects/call.c:159:18
    #166 0x7f1505a50660 in _PyObject_Vectorcall Include/cpython/abstract.h:125:16
    #167 0x7f1505a50660 in _PyObject_Vectorcall Include/cpython/abstract.h:115:1
    #168 0x7f1505a50660 in call_function Python/ceval.c:4999:13
    #169 0x7f1505a50660 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #170 0x7f1505a6758f in PyEval_EvalFrameEx Python/ceval.c:769:12
    #171 0x7f1505a6758f in function_code_fastcall Objects/call.c:283:14
    #172 0x7f1505a6758f in _PyFunction_Vectorcall.localalias Objects/call.c:410:20
    #173 0x7f1505a4fbb8 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #174 0x7f1505a4fbb8 in call_function Python/ceval.c:4999:13
    #175 0x7f1505a4fbb8 in _PyEval_EvalFrameDefault Python/ceval.c:3514:23
    #176 0x7f1505a6758f in PyEval_EvalFrameEx Python/ceval.c:769:12
    #177 0x7f1505a6758f in function_code_fastcall Objects/call.c:283:14
    #178 0x7f1505a6758f in _PyFunction_Vectorcall.localalias Objects/call.c:410:20
    #179 0x7f1505a4fbb8 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #180 0x7f1505a4fbb8 in call_function Python/ceval.c:4999:13
    #181 0x7f1505a4fbb8 in _PyEval_EvalFrameDefault Python/ceval.c:3514:23
    #182 0x7f1505a6758f in PyEval_EvalFrameEx Python/ceval.c:769:12
    #183 0x7f1505a6758f in function_code_fastcall Objects/call.c:283:14
    #184 0x7f1505a6758f in _PyFunction_Vectorcall.localalias Objects/call.c:410:20
    #185 0x7f1505a4fbb8 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #186 0x7f1505a4fbb8 in call_function Python/ceval.c:4999:13
    #187 0x7f1505a4fbb8 in _PyEval_EvalFrameDefault Python/ceval.c:3514:23
    #188 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #189 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #190 0x7f1505a77ea1 in _PyFunction_Vectorcall Objects/call.c:435:12
    #191 0x7f1505a77ea1 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #192 0x7f1505a77ea1 in method_vectorcall Objects/classobject.c:60:18
    #193 0x7f1505a50e6b in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #194 0x7f1505a50e6b in call_function Python/ceval.c:4999:13
    #195 0x7f1505a50e6b in _PyEval_EvalFrameDefault Python/ceval.c:3543:19
    #196 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #197 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #198 0x7f1505a77ea1 in _PyFunction_Vectorcall Objects/call.c:435:12
    #199 0x7f1505a77ea1 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #200 0x7f1505a77ea1 in method_vectorcall Objects/classobject.c:60:18
    #201 0x7f1505a50e6b in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #202 0x7f1505a50e6b in call_function Python/ceval.c:4999:13
    #203 0x7f1505a50e6b in _PyEval_EvalFrameDefault Python/ceval.c:3543:19
    #204 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #205 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #206 0x7f1505a77ea1 in _PyFunction_Vectorcall Objects/call.c:435:12
    #207 0x7f1505a77ea1 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #208 0x7f1505a77ea1 in method_vectorcall Objects/classobject.c:60:18
    #209 0x7f1505a50e6b in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #210 0x7f1505a50e6b in call_function Python/ceval.c:4999:13
    #211 0x7f1505a50e6b in _PyEval_EvalFrameDefault Python/ceval.c:3543:19
    #212 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #213 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #214 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #215 0x7f1505a4fbb8 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #216 0x7f1505a4fbb8 in call_function Python/ceval.c:4999:13
    #217 0x7f1505a4fbb8 in _PyEval_EvalFrameDefault Python/ceval.c:3514:23
    #218 0x7f1505a6758f in PyEval_EvalFrameEx Python/ceval.c:769:12
    #219 0x7f1505a6758f in function_code_fastcall Objects/call.c:283:14
    #220 0x7f1505a6758f in _PyFunction_Vectorcall.localalias Objects/call.c:410:20
    #221 0x7f1505a4f934 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #222 0x7f1505a4f934 in call_function Python/ceval.c:4999:13
    #223 0x7f1505a4f934 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #224 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #225 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #226 0x7f1505b16283 in PyEval_EvalCodeEx Python/ceval.c:4363:12
    #227 0x7f1505b16283 in PyEval_EvalCode.localalias Python/ceval.c:746:12
    #228 0x7f1505b1d808 in builtin_exec_impl Python/bltinmodule.c:1033:13
    #229 0x7f1505b1d808 in builtin_exec Python/clinic/bltinmodule.c.h:396:20
    #230 0x7f1505a68068 in cfunction_vectorcall_FASTCALL Objects/methodobject.c:422:24
    #231 0x7f1505a4f934 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #232 0x7f1505a4f934 in call_function Python/ceval.c:4999:13
    #233 0x7f1505a4f934 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #234 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #235 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #236 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #237 0x7f1505a4f934 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #238 0x7f1505a4f934 in call_function Python/ceval.c:4999:13
    #239 0x7f1505a4f934 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #240 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #241 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #242 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #243 0x7f1505a506da in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #244 0x7f1505a506da in call_function Python/ceval.c:4999:13
    #245 0x7f1505a506da in _PyEval_EvalFrameDefault Python/ceval.c:3497:23
    #246 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #247 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #248 0x7f1505a6762a in _PyFunction_Vectorcall.localalias Objects/call.c:435:12
    #249 0x7f1505a4f934 in _PyObject_Vectorcall Include/cpython/abstract.h:127:11
    #250 0x7f1505a4f934 in call_function Python/ceval.c:4999:13
    #251 0x7f1505a4f934 in _PyEval_EvalFrameDefault Python/ceval.c:3528:19
    #252 0x7f1505a4dd80 in PyEval_EvalFrameEx Python/ceval.c:769:12
    #253 0x7f1505a4dd80 in _PyEval_EvalCodeWithName.localalias Python/ceval.c:4334:14
    #254 0x7f1505b16283 in PyEval_EvalCodeEx Python/ceval.c:4363:12
    #255 0x7f1505b16283 in PyEval_EvalCode.localalias Python/ceval.c:746:12
    #256 0x7f1505b242cd in run_eval_code_obj Python/pythonrun.c:1125:9
    #257 0x7f1505b1de91 in run_mod Python/pythonrun.c:1147:9
    #258 0x7f1505b1a077 in PyRun_StringFlags.localalias Python/pythonrun.c:1034:15
    #259 0x7f1505b19eab in PyRun_SimpleStringFlags.localalias Python/pythonrun.c:460:9
    #260 0x7f1505b35260 in pymain_run_command Modules/main.c:258:11
    #261 0x7f1505b35260 in pymain_run_python Modules/main.c:597:21
    #262 0x7f1505b35260 in Py_RunMain.localalias Modules/main.c:685:5
    #263 0x7f1505b0368a in Py_BytesMain Modules/main.c:739:12
    #264 0x7f150568c656 in __libc_start_call_main glibc-2.34/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #265 0x7f150568c717 in __libc_start_main_impl glibc-2.34/csu/../csu/libc-start.c:409:3
    #266 0x401060 in _start glibc-2.34/csu/../sysdeps/x86_64/start.S:116

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV Include/internal/pycore_object.h:70:5 in _PyObject_GC_UNTRACK_impl
==1744834==ABORTING
```